### PR TITLE
Implement beta range filter

### DIFF
--- a/tests/pipeline/test_filters_beta.py
+++ b/tests/pipeline/test_filters_beta.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pandas as pd
+
+from coint2.pipeline.filters import filter_pairs_by_coint_and_half_life
+
+
+def test_filter_pairs_beta_range() -> None:
+    np.random.seed(0)
+    n = 100
+    idx = pd.date_range("2020-01-01", periods=n, freq="D")
+    x = np.cumsum(np.random.normal(0, 1, n))
+    spread = np.zeros(n)
+    for i in range(1, n):
+        spread[i] = 0.5 * spread[i - 1] + np.random.normal(0, 0.1)
+    y = 1000 * x + spread
+    df = pd.DataFrame({"A": y, "B": x}, index=idx)
+
+    pairs = [("A", "B")]
+    result = filter_pairs_by_coint_and_half_life(
+        pairs,
+        df,
+        pvalue_threshold=0.99,
+        min_half_life=0.1,
+        max_half_life=1000,
+        min_mean_crossings=0,
+        min_correlation=0.0,
+        max_correlation=1.0,
+        min_spread_std=0.0,
+        max_spread_std=1000.0,
+        adaptive_quantiles=False,
+    )
+
+    assert result == []


### PR DESCRIPTION
## Summary
- enforce realistic beta values when selecting tradable pairs
- log stats for pairs filtered by extreme beta
- test beta filtering logic

## Testing
- `pytest tests/pipeline/test_filters_beta.py -q`
- `pytest -q` *(fails: test_load_all_data_cache, test_threaded_cache_reload, test_zero_std_handling, test_optimized_performance, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870129850e083318eee545aaad491cb