### PR TITLE
Implement rolling calculation for pair backtester

### DIFF
--- a/src/coint2/cli.py
+++ b/src/coint2/cli.py
@@ -52,16 +52,9 @@ def backtest(ctx: click.Context, pair: str) -> None:
         click.echo("No data available for the pair")
         return
 
-    beta = data[s1].cov(data[s2]) / data[s2].var()
-    spread = data[s1] - beta * data[s2]
-    mean = spread.mean()
-    std = spread.std()
-
     bt = PairBacktester(
         data,
-        beta=beta,
-        spread_mean=mean,
-        spread_std=std,
+        rolling_window=cfg.backtest.rolling_window,
         z_threshold=cfg.backtest.zscore_threshold,
         z_exit=getattr(cfg.backtest, 'zscore_exit', 0.0),
         commission_pct=getattr(cfg.backtest, 'commission_pct', 0.0),

--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -269,12 +269,10 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
                 # Нормализация: оба ряда начинаются с 100
                 if not pair_data.empty:
                     pair_data = pair_data / pair_data.iloc[0] * 100
-                
+
                 bt = PairBacktester(
                     pair_data,
-                    beta=beta,
-                    spread_mean=mean,
-                    spread_std=std,
+                    rolling_window=cfg.backtest.rolling_window,
                     z_threshold=cfg.backtest.zscore_threshold,
                     z_exit=getattr(cfg.backtest, 'zscore_exit', 0.0),
                     commission_pct=getattr(cfg.backtest, 'commission_pct', 0.0),


### PR DESCRIPTION
## Summary
- make PairBacktester compute beta/mean/std on a rolling window
- adapt CLI and orchestrator to new PairBacktester API
- update manual backtest logic in tests
- adjust walk-forward test expectations for new metrics

## Testing
- `pytest tests/engine/test_backtest_engine.py::test_backtester_outputs -q`
- `pytest tests/engine/test_backtest_engine.py::test_zero_std_handling -q`
- `pytest tests/pipeline/test_walk_forward.py::test_walk_forward -q`


------
https://chatgpt.com/codex/tasks/task_e_687021effb3c8331847bebde35301976