### PR TITLE
Add trade log export to backtester and orchestrator

### DIFF
--- a/src/coint2/engine/backtest_engine.py
+++ b/src/coint2/engine/backtest_engine.py
@@ -53,6 +53,9 @@ class PairBacktester:
         self.take_profit_multiplier = take_profit_multiplier
         self.wait_for_candle_close = wait_for_candle_close
         self.max_margin_usage = max_margin_usage
+        self.s1 = pair_data.columns[0]
+        self.s2 = pair_data.columns[1]
+        self.trades_log: list[dict] = []
 
     def run(self) -> None:
         """Run backtest and store results in ``self.results``."""
@@ -128,6 +131,13 @@ class PairBacktester:
         trades_col_idx = df.columns.get_loc("trades")
         costs_col_idx = df.columns.get_loc("costs")
         pnl_col_idx = df.columns.get_loc("pnl")
+
+        # Variables for detailed trade logging
+        entry_datetime = None
+        entry_spread = 0.0
+        entry_position_size = 0.0
+        entry_index = 0
+        current_trade_pnl = 0.0
 
         for i in range(1, len(df)):
             if (
@@ -338,11 +348,48 @@ class PairBacktester:
                 if current_exposure > max_allowed_exposure and max_allowed_exposure > 0:
                     new_position = new_position * (max_allowed_exposure / current_exposure)
             costs = trades * trade_value * total_cost_pct
+            step_pnl = pnl - costs
 
             df.iat[i, position_col_idx] = new_position
             df.iat[i, trades_col_idx] = trades
             df.iat[i, costs_col_idx] = costs
-            df.iat[i, pnl_col_idx] = pnl - costs
+            df.iat[i, pnl_col_idx] = step_pnl
+
+            # Update trade PnL accumulator if a trade is open
+            if position != 0 or (position == 0 and new_position != 0):
+                current_trade_pnl += step_pnl
+
+            # Handle entry logging
+            if position == 0 and new_position != 0:
+                entry_datetime = df.index[i]
+                entry_spread = spread_curr
+                entry_position_size = new_position
+                entry_index = i
+
+            # Handle exit logging
+            if position != 0 and new_position == 0 and entry_datetime is not None:
+                exit_datetime = df.index[i]
+                if isinstance(df.index, pd.DatetimeIndex):
+                    duration_hours = (exit_datetime - entry_datetime).total_seconds() / 3600
+                else:
+                    duration_hours = float(i - entry_index)
+
+                trade_info = {
+                    'pair': f"{self.s1}-{self.s2}",
+                    'entry_datetime': entry_datetime,
+                    'exit_datetime': exit_datetime,
+                    'position_type': 'long' if entry_position_size > 0 else 'short',
+                    'entry_price_spread': entry_spread,
+                    'exit_price_spread': spread_curr,
+                    'pnl': current_trade_pnl,
+                    'exit_reason': df.loc[df.index[i], 'exit_reason'],
+                    'trade_duration_hours': duration_hours,
+                }
+                self.trades_log.append(trade_info)
+                current_trade_pnl = 0.0
+                entry_datetime = None
+                entry_spread = 0.0
+                entry_position_size = 0.0
 
             position = new_position
 
@@ -350,10 +397,20 @@ class PairBacktester:
 
         self.results = df
 
-    def get_results(self) -> pd.DataFrame:
+    def get_results(self) -> dict:
         if self.results is None:
             raise ValueError("Backtest not yet run")
-        return self.results[["spread", "z_score", "position", "pnl", "cumulative_pnl"]]
+
+        return {
+            "spread": self.results["spread"],
+            "z_score": self.results["z_score"],
+            "position": self.results["position"],
+            "trades": self.results["trades"],
+            "costs": self.results["costs"],
+            "pnl": self.results["pnl"],
+            "cumulative_pnl": self.results["cumulative_pnl"],
+            "trades_log": self.trades_log,
+        }
 
     def get_performance_metrics(self) -> dict:
         if self.results is None or self.results.empty:

--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -101,6 +101,7 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
     equity_data = []
     pair_count_data = []
     trade_stats = []
+    all_trades_log = []
     equity = cfg.portfolio.initial_capital
     equity_curve = [equity]
     equity_data.append((start_date, equity))
@@ -288,6 +289,7 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
                 )
                 bt.run()
                 results = bt.get_results()
+                all_trades_log.extend(results.get('trades_log', []))
                 pnl_series = results["pnl"]
                 step_pnl = step_pnl.add(pnl_series, fill_value=0)
                 total_step_pnl += pnl_series.sum()
@@ -455,6 +457,11 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
                 trades_df = pd.DataFrame(trade_stats)
                 trades_df.to_csv(results_dir / "trade_statistics.csv", index=False)
                 logger.info(f"🔄 Статистика по сделкам сохранена: {results_dir / 'trade_statistics.csv'}")
+
+            if all_trades_log:
+                trades_log_df = pd.DataFrame(all_trades_log)
+                trades_log_df.to_csv(results_dir / "trades_log.csv", index=False)
+                logger.info(f"📓 Детальный лог сделок сохранен: {results_dir / 'trades_log.csv'}")
                 
         except Exception as e:
             logger.error(f"Ошибка при создании отчетов: {e}")

--- a/tests/engine/test_backtest_engine.py
+++ b/tests/engine/test_backtest_engine.py
@@ -195,6 +195,14 @@ def test_backtester_outputs():
     bt.run()
     result = bt.get_results()
 
+    result_df = pd.DataFrame({
+        "spread": result["spread"],
+        "z_score": result["z_score"],
+        "position": result["position"],
+        "pnl": result["pnl"],
+        "cumulative_pnl": result["cumulative_pnl"],
+    })
+
     # Сравниваем с эталоном
     expected = manual_backtest(
         data,
@@ -209,7 +217,8 @@ def test_backtester_outputs():
     )
     expected_for_comparison = expected[["spread", "z_score", "position", "pnl", "cumulative_pnl"]]
     
-    pd.testing.assert_frame_equal(result, expected_for_comparison)
+    pd.testing.assert_frame_equal(result_df, expected_for_comparison)
+    assert isinstance(result["trades_log"], list)
 
     # Проверяем метрики
     metrics = bt.get_performance_metrics()
@@ -254,6 +263,14 @@ def test_zero_std_handling() -> None:
     bt.run()
     result = bt.get_results()
 
+    result_df = pd.DataFrame({
+        "spread": result["spread"],
+        "z_score": result["z_score"],
+        "position": result["position"],
+        "pnl": result["pnl"],
+        "cumulative_pnl": result["cumulative_pnl"],
+    })
+
     expected = manual_backtest(
         data,
         rolling_window,
@@ -267,7 +284,8 @@ def test_zero_std_handling() -> None:
     )
     expected_for_comparison = expected[["spread", "z_score", "position", "pnl", "cumulative_pnl"]]
 
-    pd.testing.assert_frame_equal(result, expected_for_comparison)
+    pd.testing.assert_frame_equal(result_df, expected_for_comparison)
+    assert isinstance(result["trades_log"], list)
 
     metrics = bt.get_performance_metrics()
     assert metrics == {"sharpe_ratio": 0.0, "max_drawdown": 0.0, "total_pnl": 0.0}


### PR DESCRIPTION
## Summary
- track trade details during backtests
- return `trades_log` from `PairBacktester`
- collect all trades during walk-forward and save to CSV
- update tests for new `trades_log` output

## Testing
- `pytest tests/engine/test_backtest_engine.py::test_backtester_outputs tests/engine/test_backtest_engine.py::test_zero_std_handling -q`
- `pytest -q` *(fails: FileNotFoundError & assertion errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68713d2caf388331be789283debe671c