### PR TITLE
Fix Sharpe ratio to use returns

### DIFF
--- a/src/coint2/core/performance.py
+++ b/src/coint2/core/performance.py
@@ -29,26 +29,28 @@ def max_drawdown_on_equity(equity_curve: pd.Series) -> float:
     drawdown = (equity_curve - running_max) / running_max
     return drawdown.min()
 
-def sharpe_ratio(pnl: pd.Series, annualizing_factor: int, risk_free_rate: float = 0.0) -> float:
-    """Compute annualized Sharpe ratio of a PnL series.
+def sharpe_ratio(returns: pd.Series, annualizing_factor: float) -> float:
+    """Calculates the annualized Sharpe ratio from a series of returns.
 
     Parameters
     ----------
-    pnl : pd.Series
-        Profit and loss series.
-    risk_free_rate : float, optional
-        Daily risk free rate, by default ``0.0``.
+    returns : pd.Series
+        Series of strategy returns expressed in percentages (not PnL).
+    annualizing_factor : float
+        Factor used to annualize the Sharpe ratio (e.g. number of trading days).
 
     Returns
     -------
     float
-        Annualized Sharpe ratio.
+        Annualized Sharpe ratio. Returns ``0.0`` if the standard deviation of
+        ``returns`` is zero.
     """
-    excess_returns = pnl - risk_free_rate
-    if excess_returns.std(ddof=0) == 0:
-        return np.nan
-    daily_sharpe = excess_returns.mean() / excess_returns.std(ddof=0)
-    return daily_sharpe * np.sqrt(annualizing_factor)
+
+    if returns.std() == 0:
+        return 0.0
+
+    # Assume risk free rate is zero
+    return np.sqrt(annualizing_factor) * returns.mean() / returns.std()
 
 
 def max_drawdown(cumulative_pnl: pd.Series) -> float:

--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -393,7 +393,11 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
             capital_per_pair = portfolio.calculate_position_risk_capital(
                 cfg.portfolio.risk_per_position_pct
             )
-            sharpe_abs = performance.sharpe_ratio(aggregated_pnl, cfg.backtest.annualizing_factor)
+            # Calculate Sharpe ratio using portfolio percentage returns
+            daily_returns = equity_series.pct_change().dropna()
+            sharpe_abs = performance.sharpe_ratio(
+                daily_returns, cfg.backtest.annualizing_factor
+            )
             sharpe_on_returns = performance.sharpe_ratio_on_returns(
                 aggregated_pnl, capital_per_pair, cfg.backtest.annualizing_factor
             )
@@ -468,5 +472,11 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
                 
         except Exception as e:
             logger.error(f"Ошибка при создании отчетов: {e}")
-    
+
+    # Calculate and display Sharpe ratio on portfolio returns for verification
+    equity_curve = portfolio.equity_curve
+    daily_returns = equity_curve.pct_change().dropna()
+    sharpe = performance.sharpe_ratio(daily_returns, cfg.backtest.annualizing_factor)
+    print(f"Correct Sharpe Ratio: {sharpe}")
+
     return base_metrics

--- a/tests/core/test_performance.py
+++ b/tests/core/test_performance.py
@@ -6,7 +6,7 @@ from coint2.core import performance
 
 def test_sharpe_ratio_uses_annualizing_factor():
     pnl = pd.Series([0.01, -0.02, 0.03, -0.01, 0.02])
-    daily_sharpe = pnl.mean() / pnl.std(ddof=0)
+    daily_sharpe = pnl.mean() / pnl.std()
 
     result_252 = performance.sharpe_ratio(pnl, 252)
     result_365 = performance.sharpe_ratio(pnl, 365)

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -87,7 +87,8 @@ def manual_walk_forward(handler: DataHandler, cfg: AppConfig) -> dict:
     equity_series = cum + cfg.portfolio.initial_capital
     capital_per_pair = cfg.portfolio.initial_capital * cfg.portfolio.risk_per_position_pct
 
-    sharpe_abs = performance.sharpe_ratio(overall, cfg.backtest.annualizing_factor)
+    daily_returns = equity_series.pct_change().dropna()
+    sharpe_abs = performance.sharpe_ratio(daily_returns, cfg.backtest.annualizing_factor)
     sharpe_ret = performance.sharpe_ratio_on_returns(
         overall, capital_per_pair, cfg.backtest.annualizing_factor
     )


### PR DESCRIPTION
## Summary
- compute Sharpe ratio from returns in performance util
- use equity curve percentage returns in walk-forward orchestrator
- print resulting Sharpe ratio for debug
- update unit tests

## Testing
- `pytest -q` *(fails: cannot infer freq due to missing arrow kernel)*

------
https://chatgpt.com/codex/tasks/task_e_68715f9fc05483319e2118ee363e3ccb