### PR TITLE
Improve data loader interpolation

### DIFF
--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -145,7 +145,8 @@ def test_load_pair_data(tmp_path: Path) -> None:
     freq_val = pd.infer_freq(expected.index)
     if freq_val:
         expected = expected.asfreq(freq_val)
-    limit = max(1, int(len(expected) * 0.1))
+    limit = 5
+    expected = expected.interpolate(method="linear", limit=limit)
     expected = expected.ffill(limit=limit).bfill(limit=limit)
     expected = expected[["AAA", "BBB"]].dropna()
     expected = expected.loc[pd.Timestamp("2021-01-02"): pd.Timestamp("2021-01-04")]
@@ -393,8 +394,8 @@ def test_fill_limit_pct_application(tmp_path: Path) -> None:
     expected_a[50:60] = np.nan
     expected_b[60:70] = np.nan
     expected = pd.DataFrame({"AAA": expected_a, "BBB": expected_b})
-    limit = int(len(expected) * 0.1)
-    limit = max(1, int(len(expected) * 0.1))
+    limit = 5
+    expected = expected.interpolate(method="linear", limit=limit)
     expected = expected.ffill(limit=limit).bfill(limit=limit)
     expected = expected[["AAA", "BBB"]].dropna()
     expected.index.name = 'timestamp'


### PR DESCRIPTION
## Summary
- use linear interpolation with small limit when loading pair data
- speed up `preload_all_data` with Dask
- update tests for new interpolation behaviour

## Testing
- `pytest tests/core/test_data_loader.py::test_load_pair_data tests/core/test_data_loader.py::test_fill_limit_pct_application -q`
- `pytest -q` *(fails: test_load_all_data_cache, test_threaded_cache_reload, test_cache_autorefresh, test_load_all_data_for_period, test_clear_cache, test_fast_coint_with_nan_values, test_rglob_finds_all_files, test_half_life_numba, test_find_cointegrated_pairs, test_walk_forward, test_pivot, test_load_config, test_infer_frequency_regular[H], test_infer_frequency_regular[15T])*

------
https://chatgpt.com/codex/tasks/task_e_687164abc8448331a0dca787eab478eb