### PR TITLE
Fix time stop parameter passing and add tests

### DIFF
--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -292,6 +292,7 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
                     cooldown_periods=int(getattr(cfg.backtest, 'cooldown_hours', 0) * 60 / 15),  # 15-минутный таймфрейм
                     wait_for_candle_close=getattr(cfg.backtest, 'wait_for_candle_close', False),
                     max_margin_usage=getattr(cfg.portfolio, 'max_margin_usage', 1.0),
+                    # half_life is required for time_stop logic
                     half_life=metrics.get('half_life'),
                     time_stop_multiplier=getattr(cfg.backtest, 'time_stop_multiplier', None),
                 )

--- a/tests/engine/test_backtest_engine.py
+++ b/tests/engine/test_backtest_engine.py
@@ -336,3 +336,31 @@ def test_zero_std_handling() -> None:
 
     metrics = bt.get_performance_metrics()
     assert metrics == {"sharpe_ratio": 0.0, "max_drawdown": 0.0, "total_pnl": 0.0}
+
+
+def test_time_stop() -> None:
+    """Ensures that trades are closed when the time stop is exceeded."""
+    data = pd.DataFrame({
+        "Y": np.arange(30) + 2 * np.sin(np.linspace(0, 2 * np.pi, 30)),
+        "X": np.arange(30),
+    })
+
+    bt = PairBacktester(
+        data,
+        rolling_window=5,
+        z_threshold=1.0,
+        z_exit=0.0,
+        commission_pct=0.0,
+        slippage_pct=0.0,
+        capital_at_risk=100.0,
+        stop_loss_multiplier=2.0,
+        cooldown_periods=0,
+        half_life=2,
+        time_stop_multiplier=2,
+    )
+    bt.run()
+
+    assert bt.trades_log, "No trades were executed"
+    first_trade = bt.trades_log[0]
+    assert first_trade["exit_reason"] == "time_stop"
+    assert first_trade["trade_duration_hours"] > bt.half_life * bt.time_stop_multiplier


### PR DESCRIPTION
## Summary
- document half_life being passed into `PairBacktester`
- add unit test covering time based stop logic

## Testing
- `pytest tests/engine/test_backtest_engine.py::test_time_stop -q`

------
https://chatgpt.com/codex/tasks/task_e_68716dd52df08331a2bb6a42cff2f0b7