### PR TITLE
Use PyYAML for config loading

### DIFF
--- a/src/yaml_config.py
+++ b/src/yaml_config.py
@@ -1,43 +1,10 @@
-import ast
-from collections.abc import Iterable
+import yaml
+from pathlib import Path
 from typing import Any
 
 
-def safe_load(stream: Iterable[str] | str) -> Any:
-    if hasattr(stream, "read"):
-        text = stream.read()
-    else:
-        text = str(stream)
-
-    # remove comments and empty lines
-    lines = []
-    for line in text.splitlines():
-        line = line.split("#", 1)[0].rstrip()
-        if line:
-            lines.append(line)
-
-    result: dict[str, Any] = {}
-    stack = [result]
-    indents = [0]
-    for raw in lines:
-        indent = len(raw) - len(raw.lstrip())
-        key, _, val = raw.partition(":")
-        key = key.strip()
-        val = val.strip()
-
-        while indent < indents[-1]:
-            stack.pop()
-            indents.pop()
-
-        if not val:
-            new_dict: dict[str, Any] = {}
-            stack[-1][key] = new_dict
-            stack.append(new_dict)
-            indents.append(indent + 2)
-        else:
-            try:
-                value = ast.literal_eval(val)
-            except Exception:
-                value = val.strip('"\'')
-            stack[-1][key] = value
-    return result
+def load_config(path: Path | str) -> dict[str, Any]:
+    """Load configuration from a YAML file using ``yaml.safe_load``."""
+    file_path = Path(path)
+    with file_path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- replace the custom YAML parser with a simple `load_config` that uses `yaml.safe_load`

## Testing
- `pytest tests/test_yaml_import.py -q`
- `pytest -q` *(fails: test_load_all_data_cache, test_threaded_cache_reload, test_cache_autorefresh, test_fast_coint_with_nan_values, test_rglob_finds_all_files, test_half_life_numba, test_find_cointegrated_pairs, test_walk_forward, test_load_config, test_infer_frequency_regular[H], test_infer_frequency_regular[15T])*

------
https://chatgpt.com/codex/tasks/task_e_6871750e6c50833186c64e77ccf1ce51